### PR TITLE
Adjusted build for BLAS and MPI implementation based on user specification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,23 @@ find_package(OpenMP REQUIRED)
 find_package(CUDAExaTN)
 find_package(BLAS)
 
-
 if(NOT CUDA_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_GPU")
 endif()
 
+#If BLAS implementation not user specified, try to import
+#Otherwise proceed with "none"
+if(NOT BLAS_LIB)
+  if(BLAS_FOUND)
+    set(BLAS_LIB ${BLA_VENDOR})
+  endif()
+endif()
+
+
+#If MPI not user specified, default to no MPI
+if(NOT MPI_LIB)
+  set(MPI_LIB NONE)
+endif()
 
 message(STATUS "MPIRUN: ${MPIEXEC_EXECUTABLE}")
 include_directories(${CMAKE_BINARY_DIR}/tpls/cppmicroservices/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ project(exatn LANGUAGES CXX Fortran)
 
 option(CUDA_HOST_COMPILER "Provide the host compiler for nvcc" "")
 option(EXATN_BUILD_TESTS "Build ExaTN tests" OFF)
-option(BLAS_LIB "Provide the BLAS libraries location" "")
-option(MPI_LIB "Provide the MPI libraries location" "")
+option(BLAS_LIB "Provide the BLAS implementation" "")
+option(MPI_LIB "Provide the MPI implementation" "")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(
@@ -42,14 +42,16 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 include(CTest)
 
-find_package(MPI REQUIRED)
+find_package(MPI)
 find_package(OpenMP REQUIRED)
 find_package(CUDAExaTN)
-find_package(BLAS REQUIRED)
+find_package(BLAS)
+
 
 if(NOT CUDA_FOUND)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_GPU")
 endif()
+
 
 message(STATUS "MPIRUN: ${MPIEXEC_EXECUTABLE}")
 include_directories(${CMAKE_BINARY_DIR}/tpls/cppmicroservices/include)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ $ mkdir build && cd build
 $ cmake .. -DEXATN_BUILD_TESTS=TRUE -DCUDA_HOST_COMPILER=<PATH_TO_CUDA_COMPATIBLE_C++_COMPILER>
   For Python API add:
   -DPYTHON_INCLUDE_DIR=$(python3 -c "import sysconfig; print(sysconfig.get_paths()['platinclude'])")
-  To specify MPI and/or BLAS library paths add:
-  -DBLAS_LIB=<PATH_TO_BLASLIB> -DMPI_LIB=<PATH_TO_MPILIB>
+  If different from OPENMPI or ATLAS, specify the name of the implementation with:
+  -DBLAS_LIB=<BLAS_IMPLEMENTATION> -DMPI_LIB=<MPI_IMPLEMENTATION>
 $ make install
 ```
 Setting the CUDA_HOST_COMPILER is necessary if your default `g++` is not compatible

--- a/src/driver-rpc/CMakeLists.txt
+++ b/src/driver-rpc/CMakeLists.txt
@@ -1,5 +1,8 @@
 
-add_subdirectory(mpi)
+
+if(MPI_FOUND)
+  add_subdirectory(mpi)
+endif()
 
 file (GLOB HEADERS *.hpp)
 

--- a/tpls/CMakeLists.txt
+++ b/tpls/CMakeLists.txt
@@ -44,37 +44,30 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ExaTensor/include/talshxx.hpp")
   set(TALSHXX_EXISTS "YES")
 endif()
 
-list(GET MPI_Fortran_INCLUDE_PATH 0 MPI_FORTRAN_INCLUDE)
-get_filename_component(MPI_ROOT_DIR ${MPI_FORTRAN_INCLUDE} DIRECTORY)
-get_filename_component(MPI_BIN_PATH ${MPI_CXX_COMPILER} DIRECTORY)
+if(MPI_FOUND)
+  list(GET MPI_Fortran_INCLUDE_PATH 0 MPI_FORTRAN_INCLUDE)
+  get_filename_component(MPI_ROOT_DIR ${MPI_FORTRAN_INCLUDE} DIRECTORY)
+  get_filename_component(MPI_BIN_PATH ${MPI_CXX_COMPILER} DIRECTORY)
+endif()
 
 message(STATUS "MPI bin path: ${MPI_BIN_PATH}")
 message(STATUS "MPI root path: ${MPI_ROOT_DIR}")
 message(STATUS "CUDA Host Compiler: ${CMAKE_CXX_COMPILER}")
+message(STATUS "The MPI_LIB implementation is set to ${MPI_LIB}")
+message(STATUS "The BLAS_LIB implementation is set to ${BLAS_LIB}")
 
 if (APPLE)
-message(STATUS "THIS IS APPLE, BUILDING EXATENSOR ${CMAKE_Fortran_COMPILER}")
-  if(NOT MPI_LIB)
-    set(MPI_LIB MPICH)
-  endif()
+  message(STATUS "THIS IS APPLE, BUILDING EXATENSOR ${CMAKE_Fortran_COMPILER}")
 
   add_custom_target(
     exatensor-build
-    COMMAND ${CMAKE_COMMAND} -E env CPP_GNU=${CMAKE_CXX_COMPILER} CC_GNU=${CMAKE_C_COMPILER} FC_GNU=${CMAKE_Fortran_COMPILER} MPILIB=${MPI_LIB} BLASLIB=NONE
+    COMMAND ${CMAKE_COMMAND} -E env CPP_GNU=${CMAKE_CXX_COMPILER} CC_GNU=${CMAKE_C_COMPILER} FC_GNU=${CMAKE_Fortran_COMPILER} MPILIB=${MPI_LIB} BLASLIB=${BLAS_LIB}
             PATH_MPICH_INC=${MPI_ROOT_DIR}/include EXA_NO_BUILD=${TALSHXX_EXISTS}
             PATH_MPICH_LIB=${MPI_ROOT_DIR}/lib
             PATH_MPICH_BIN=${MPI_BIN_PATH} EXA_OS=NO_LINUX GPU_CUDA=NOCUDA EXA_TALSH_ONLY=YES EXATN_SERVICE=YES make
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ExaTensor)
 
 else()
-  #Check that MPI and BLAS libraries were set at configuration - if not set to default
-  #these are the same regardless of whether or not the CUDA compiler is set
-  if(NOT MPI_LIB)
-    set(MPI_LIB OPENMPI)
-  endif()
-  if(NOT BLAS_LIB)
-    set(BLAS_LIB ATLAS)
-  endif()
 
   if(CUDA_FOUND)
     message(STATUS "CUDA ROOT: ${CUDA_TOOLKIT_ROOT_DIR}")


### PR DESCRIPTION
Changed build to allow user specification for BLAS and MPI specification according to the suggestion from @DmitryLyakh at this [link](https://github.com/ORNL-QCI/exatn/issues/1#issuecomment-514251679).