### PR TITLE
Tnguyen/devel

### DIFF
--- a/python/examples/benchmark.py
+++ b/python/examples/benchmark.py
@@ -44,22 +44,30 @@ while True:
     lhsTensorOperand1 = exprSplits[1]
     lhsTensorOperand2 = exprSplits[3]
     #print("{}:{}:{}".format(rhsTensor, lhsTensorOperand1, lhsTensorOperand2)) 
+    
     # LHS (result) 'C' tensor
     assert(rhsTensor[0] == "C")
     exatn.createTensor("C", getTensorDimArray(rhsTensor, vardict), 0.0)
     
     # RHS A tensor
     assert(lhsTensorOperand1[0] == "A") 
-    exatn.createTensor("A", getTensorDimArray(lhsTensorOperand1, vardict), np.random.normal())
+    exatn.createTensor("A", getTensorDimArray(lhsTensorOperand1, vardict), 0.0)
+    # Initialize random tensor body
+    exatn.initTensorRnd("A")
+    
     # RHS B tensor
     assert(lhsTensorOperand2[0] == "B") 
-    exatn.createTensor("B", getTensorDimArray(lhsTensorOperand2, vardict), np.random.normal())
+    exatn.createTensor("B", getTensorDimArray(lhsTensorOperand2, vardict), 0.0)
+    # Initialize random tensor body
+    exatn.initTensorRnd("B")
+
     # Convert [] to () (ExaTN convention)
     exatnExpr = expr.replace('[','(').replace(']',')')
-    # Evaluate
+    # Evaluate by tensor contraction
     start = time.process_time()
-    exatn.evaluateTensorNetwork('Test', exatnExpr)
+    contractOk = exatn.contractTensors(exatnExpr)
     elapsedTime = time.process_time() - start
+    assert(contractOk is True)
     
     # Destroy tensors
     exatn.destroyTensor("A")

--- a/python/examples/benchmark.py
+++ b/python/examples/benchmark.py
@@ -77,4 +77,20 @@ while True:
     gFlops = gFlops/elapsedTime
     print("Test {}: {} ({}) || Time elapsed: {} [sec]; GFlops/sec: {}".format(count, expr, dimVars, elapsedTime, gFlops)) 
 
+    # Compare with numpy
+    sizeA = getTensorDimArray(lhsTensorOperand1, vardict)
+    sizeB = getTensorDimArray(lhsTensorOperand2, vardict)
+    A = np.empty(sizeA, dtype = np.float64)
+    B = np.empty(sizeB, dtype = np.float64)
+    randA = np.random.randn(*A.shape)
+    randB = np.random.randn(*B.shape)
+    indA = lhsTensorOperand1[2:-1]
+    indB = lhsTensorOperand2[2:-1]
+    indC = rhsTensor[2:-1]
+    npStart = time.process_time()
+    # Use numpy einsum to perform tensor contraction
+    C_ = np.einsum("%s,%s->%s"%(indA.replace(',',''), indB.replace(',',''), indC.replace(',','')), randA, randB)
+    npElapsedTime = time.process_time() - start
+    print("  ==> Test {}: Numpy time elapsed: {} [sec]; ExaTN speed-up: {}".format(count, npElapsedTime, npElapsedTime/elapsedTime)) 
+
 inputFile.close() 

--- a/python/exatn-py.cpp
+++ b/python/exatn-py.cpp
@@ -377,6 +377,41 @@ py::class_<exatn::numerics::TensorExpansion,
       return exatn::initTensorRndSync(name);
     },
     "");
+  // Decomposes a tensor into three tensor factors via SVD. The symbolic
+  // tensor contraction specification specifies the decomposition,
+  // for example:
+  //   D(a,b,c,d,e) = L(c,i,e,j) * S(i,j) * R(b,j,a,i,d)
+  // where
+  //   L(c,i,e,j) is the left SVD factor,
+  //   R(b,j,a,i,d) is the right SVD factor,
+  //   S(i,j) is the middle SVD factor (the diagonal with singular values).
+  m.def(
+    "svd", 
+    [](const std::string& contraction) {
+      return exatn::decomposeTensorSVDSync(contraction);
+    },
+    "");
+  // SVD with singular values absorbed by the left tensor
+  m.def(
+    "svdL", 
+    [](const std::string& contraction) {
+      return exatn::decomposeTensorSVDLSync(contraction);
+    },
+    "");
+  // SVD with singular values absorbed by the right tensor
+  m.def(
+    "svdR", 
+    [](const std::string& contraction) {
+      return exatn::decomposeTensorSVDRSync(contraction);
+    },
+    "");
+  // SVD with square root of singular values absorbed by the left and right tensors
+  m.def(
+    "svdLR", 
+    [](const std::string& contraction) {
+      return exatn::decomposeTensorSVDLRSync(contraction);
+    },
+    "");
 }
 } // namespace exatn
 

--- a/python/exatn-py.cpp
+++ b/python/exatn-py.cpp
@@ -346,6 +346,37 @@ py::class_<exatn::numerics::TensorExpansion,
     return py::array();
   });
   m.def("destroyTensor", &destroyTensor, "");
+  // exatn_numerics API
+  // Performs tensor contraction: tensor0 += tensor1 * tensor2 * alpha 
+  // Input: symbolic tensor contraction specification & alpha factor (default = 1.0)
+  m.def(
+    "contractTensors", 
+    // Default contraction: alpha = 1.0
+    [](const std::string& contraction) {
+      return exatn::contractTensorsSync(contraction, 1.0);
+    },
+    "");
+  m.def(
+    "contractTensors", 
+    // Floating-point alpha
+    [](const std::string& contraction, double alpha) {
+      return exatn::contractTensorsSync(contraction, alpha);
+    },
+    "");
+  m.def(
+    "contractTensors", 
+    // Complex alpha
+    [](const std::string& contraction, std::complex<double> alpha) {
+      return exatn::contractTensorsSync(contraction, alpha);
+    },
+    "");
+  // Initializes the tensor body with random values.
+  m.def(
+    "initTensorRnd", 
+    [](const std::string& name) {
+      return exatn::initTensorRndSync(name);
+    },
+    "");
 }
 } // namespace exatn
 


### PR DESCRIPTION
- Modified the Python example benchmark script to use `exatn::contractTensors` rather than evaluating the tensor network. Also, added `numpy.einsum` as a baseline for perf. comparison.

- Exposed a few exatn numerics API's to Python: `contractTensors`, `initTensorRnd`, and SVD