### PR TITLE
Conditioned some std::cout logging based on build type

### DIFF
--- a/src/runtime/executor/node_executors/talsh/node_executor_talsh.cpp
+++ b/src/runtime/executor/node_executors/talsh/node_executor_talsh.cpp
@@ -48,6 +48,11 @@ inline MPI_Datatype get_mpi_tensor_element_kind(int talsh_data_kind)
 
 void TalshNodeExecutor::initialize(const ParamConf & parameters)
 {
+#ifndef NDEBUG
+  const bool debugging = true;
+#else  
+  const bool debugging = false;
+#endif
  talsh_init_lock.lock();
  if(!talsh_initialized_){
   std::size_t host_mem_buffer_size = DEFAULT_MEM_BUFFER_SIZE;
@@ -57,7 +62,7 @@ void TalshNodeExecutor::initialize(const ParamConf & parameters)
   auto error_code = talsh::initialize(&host_mem_buffer_size);
   if(error_code == TALSH_SUCCESS){
    talsh_host_mem_buffer_size_.store(host_mem_buffer_size);
-   std::cout << "#DEBUG(exatn::runtime::TalshNodeExecutor): TAL-SH initialized with Host buffer size of " <<
+   if (debugging) std::cout << "#DEBUG(exatn::runtime::TalshNodeExecutor): TAL-SH initialized with Host buffer size of " <<
     talsh_host_mem_buffer_size_ << " bytes" << std::endl << std::flush; //debug
    talsh_initialized_ = true;
   }else{
@@ -81,6 +86,11 @@ std::size_t TalshNodeExecutor::getMemoryBufferSize() const
 
 TalshNodeExecutor::~TalshNodeExecutor()
 {
+#ifndef NDEBUG
+  const bool debugging = true;
+#else  
+  const bool debugging = false;
+#endif
  auto synced = sync(true); assert(synced);
  talsh_init_lock.lock();
  --talsh_node_exec_count_;
@@ -90,7 +100,7 @@ TalshNodeExecutor::~TalshNodeExecutor()
   talsh::printStatistics();
   auto error_code = talsh::shutdown();
   if(error_code == TALSH_SUCCESS){
-   std::cout << "#DEBUG(exatn::runtime::TalshNodeExecutor): TAL-SH shut down" << std::endl << std::flush;
+   if (debugging) std::cout << "#DEBUG(exatn::runtime::TalshNodeExecutor): TAL-SH shut down" << std::endl << std::flush;
    talsh_initialized_ = false;
   }else{
    std::cerr << "#FATAL(exatn::runtime::TalshNodeExecutor): Unable to shut down TAL-SH!" << std::endl;

--- a/src/runtime/tensor_runtime.cpp
+++ b/src/runtime/tensor_runtime.cpp
@@ -31,11 +31,16 @@ TensorRuntime::TensorRuntime(const MPICommProxy & communicator,
  graph_executor_name_(graph_executor_name), node_executor_name_(node_executor_name),
  current_dag_(nullptr), executing_(false), scope_set_(false), alive_(false)
 {
+#ifndef NDEBUG
+  const bool debugging = true;
+#else  
+  const bool debugging = false;
+#endif
   global_mpi_comm = *(communicator.get<MPI_Comm>());
   int mpi_error = MPI_Comm_size(global_mpi_comm,&num_processes_); assert(mpi_error == MPI_SUCCESS);
   mpi_error = MPI_Comm_rank(global_mpi_comm,&process_rank_); assert(mpi_error == MPI_SUCCESS);
   graph_executor_ = exatn::getService<TensorGraphExecutor>(graph_executor_name_);
-  std::cout << "#DEBUG(exatn::runtime::TensorRuntime)[MAIN_THREAD:Process " << process_rank_
+  if (debugging) std::cout << "#DEBUG(exatn::runtime::TensorRuntime)[MAIN_THREAD:Process " << process_rank_
             << "]: DAG executor set to " << graph_executor_name_ << " + "
             << node_executor_name_ << std::endl << std::flush;
   launchExecutionThread();
@@ -48,9 +53,14 @@ TensorRuntime::TensorRuntime(const ParamConf & parameters,
  graph_executor_name_(graph_executor_name), node_executor_name_(node_executor_name),
  current_dag_(nullptr), executing_(false), scope_set_(false), alive_(false)
 {
+#ifndef NDEBUG
+  const bool debugging = true;
+#else  
+  const bool debugging = false;
+#endif
   num_processes_ = 1; process_rank_ = 0;
   graph_executor_ = exatn::getService<TensorGraphExecutor>(graph_executor_name_);
-  std::cout << "#DEBUG(exatn::runtime::TensorRuntime)[MAIN_THREAD]: DAG executor set to "
+  if (debugging) std::cout << "#DEBUG(exatn::runtime::TensorRuntime)[MAIN_THREAD]: DAG executor set to "
             << graph_executor_name_ << " + " << node_executor_name_ << std::endl << std::flush;
   launchExecutionThread();
 }


### PR DESCRIPTION
There are a couple of remaining std::cout logging which can be quite repetitive in MPI mode. Especially when using within the HPC virtual decorator.

Hence, disabled these logs in RELEASE build.

Tested by: running both DEBUG and RELEASE.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>