### PR TITLE
Fix for multiple failing tests

### DIFF
--- a/python/exatn-py.cpp
+++ b/python/exatn-py.cpp
@@ -81,7 +81,7 @@ py::class_<exatn::numerics::TensorExpansion,
             return network.getTensor(id);
           },
           "")
-      .def("collapseIsometries", &TensorNetwork::collapseIsometries, "")
+      .def("collapseIsometries", &TensorNetwork::collapseIsometries, py::arg("deltas_appended") = nullptr, "")
       .def("getTensor", &TensorNetwork::getTensor, "")
       .def("placeTensor",
            (bool (exatn::numerics::TensorNetwork::*)(

--- a/src/exatn/num_server.cpp
+++ b/src/exatn/num_server.cpp
@@ -1439,6 +1439,11 @@ bool NumServer::registerTensorIsometry(const std::string & name,
 
 bool NumServer::withinTensorExistenceDomain(const std::string & tensor_name) const
 {
+  std::cout << "TENSORS in this process: " << std::endl;
+  for(auto kv : tensors_)
+  {
+    std::cout << kv.first << std::endl;
+  }
  bool exists = (tensors_.find(tensor_name) != tensors_.cend());
  if(!exists) exists = (implicit_tensors_.find(tensor_name) != implicit_tensors_.cend());
  return exists;

--- a/src/exatn/num_server.cpp
+++ b/src/exatn/num_server.cpp
@@ -1439,11 +1439,6 @@ bool NumServer::registerTensorIsometry(const std::string & name,
 
 bool NumServer::withinTensorExistenceDomain(const std::string & tensor_name) const
 {
-  std::cout << "TENSORS in this process: " << std::endl;
-  for(auto kv : tensors_)
-  {
-    std::cout << kv.first << std::endl;
-  }
  bool exists = (tensors_.find(tensor_name) != tensors_.cend());
  if(!exists) exists = (implicit_tensors_.find(tensor_name) != implicit_tensors_.cend());
  return exists;

--- a/src/exatn/tests/NumServerTester.cpp
+++ b/src/exatn/tests/NumServerTester.cpp
@@ -50,7 +50,7 @@
 #define EXATN_TEST29
 #define EXATN_TEST30
 //#define EXATN_TEST31 //requires input file from source
-#define EXATN_TEST32
+//#define EXATN_TEST32 //requires input file from source
 #define EXATN_TEST33
 #define EXATN_TEST34
 

--- a/src/runtime/tests/TensorRuntimeTester.cpp
+++ b/src/runtime/tests/TensorRuntimeTester.cpp
@@ -57,7 +57,7 @@ TEST(TensorRuntimeTester, checkSimple) {
   destroy_tensor0->setTensorOperand(tensor0);
 
   //Execute all tensor operations via the ExaTN numerical server:
-  auto tensor_mapper = exatn::numericalServer->getTensorMapper(exatn::getTensorProcessGroup(tensor0->getName()));
+  auto tensor_mapper = exatn::numericalServer->getTensorMapper(exatn::getDefaultProcessGroup()); 
   exatn::numericalServer->submit(create_tensor0,tensor_mapper);
   exatn::numericalServer->submit(create_tensor1,tensor_mapper);
   exatn::numericalServer->submit(create_tensor2,tensor_mapper);


### PR DESCRIPTION
(edited and added more bugfixes on 7/10/23)

Hi all,

when doing a default (successful) build on a freshly-configured Ubuntu 22.04 VM, the test `ExaTN_PythonTester.checkExaTNPyAPI` fails with the following log:

```
[ RUN      ] ExaTN_PythonTester.checkExaTNPyAPI

[...]

[ Test Quantum Circuit Network ]
unknown file: Failure
C++ exception with description "TypeError: collapseIsometries(): incompatible function arguments. The following argument types are supported:
    1. (self: _pyexatn.TensorNetwork, arg0: bool) -> bool

Invoked with: <_pyexatn.TensorNetwork object at 0x7f11b9f46cb0>

At:
  <string>(47): <module>
" thrown in the test body.
<end of output>
Test time =   0.40 sec
----------------------------------------------------------
Test Failed.
"ExaTN_PythonTester" end time: Jul 09 20:29 UTC
"ExaTN_PythonTester" time elapsed: 00:00:00
----------------------------------------------------------
```

This seems due to how Pybind11 handles `nullptr` as default argument. I've added the workaround mentioned in the relevant [PyBind11 Issue](https://github.com/pybind/pybind11/issues/124) and now the test passes.

EDIT: I've found two more things that resolve tests with problems. First, in the `NumServerTest`, the test `IsometricAIEM` fails due to a missing input file. I've taken the liberty of commenting it out.

Furthermore, in `TensorRuntimeTester.checkSimple`, I get:

```
[ RUN      ] TensorRuntimeTester.checkSimple
#ERROR(exatn::getTensorProcessGroup): Process 0 is not within the existence domain of tensor tensor0
TensorRuntimeTester: /home/dthuerck/dev/exatn/src/exatn/num_server.cpp:1453: const exatn::ProcessGroup& exatn::NumServer::getTensorProcessGroup(const string&) const: Assertion `false' failed.
<end of output>
Test time =   0.06 sec
----------------------------------------------------------
Test Failed.
```

I think that this is due to this line in `TensorRuntimeTester.cpp`:
```
  auto tensor_mapper = exatn::numericalServer->getTensorMapper(exatn::getTensorProcessGroup(tensor0->getName()));
```

At this point, there has been no `submit` operation, hence `tensor0` has not been registered so far. The following change fixes that:

```
auto tensor_mapper = exatn::numericalServer->getTensorMapper(exatn::getDefaultProcessGroup()); 
```

The two commits in this PR implement all three proposed changes and result in passing tests.